### PR TITLE
configure source code to no longer contain outdated reference

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,14 @@ services:
     build: 
       context: .
       dockerfile: Dockerfile
-    container_name: vpn_container
-    image: vpn_image
+    container_name: shrew-vpn-container
+    image: vpn-image
     network_mode: "host"
     privileged: true
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - ~/.Xauthority:/root/.Xauthority
+      - ./ike_github_repo/ike:/shrewsoft_vpn_container
     environment:
       - DISPLAY=${DISPLAY}
     env_file:

--- a/enter-container-bash.sh
+++ b/enter-container-bash.sh
@@ -1,0 +1,1 @@
+sudo docker exec -it shrew-vpn-container /bin/bash

--- a/ike_github_repo/ike/source/iked/ike.socket.cpp
+++ b/ike_github_repo/ike/source/iked/ike.socket.cpp
@@ -129,15 +129,6 @@ long _IKED::socket_create( IKE_SADDR & saddr, bool natt )
 			return LIBIKE_SOCKET;
 		}
 	}
-	else
-	{
-		optval = UDP_ENCAP_ESPINUDP_NON_IKE;
-		if( setsockopt( sock_info->sock, SOL_UDP, UDP_ENCAP, &optval, sizeof( optval ) ) < 0)
-		{
-			log.txt( LLOG_ERROR, "!! : socket set udp-encap non-ike option failed\n" );
-			return LIBIKE_SOCKET;
-		}
-	}
 
 #endif
 


### PR DESCRIPTION
This is a bugfix for the error:
`!! : socket set udp-encap non-ike
failed option daemon network configuration failed
( line 8, col 16 )`                                                                                                                                                                                 

when the command `iked` (to start the daemon) was run

Based off of this forum, the bug is due to a dated else statement in the ike.socket.cpp file:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=221091

removing this else statement allows the daemon to run.


Other Features:
1. Added a bash script for quickly entering into the shell for the container.
2. Modified dockerfile to name containers in my preferred kebab-case as opposed to snake_case